### PR TITLE
Add CORE postprocessor

### DIFF
--- a/results/cifar100.csv
+++ b/results/cifar100.csv
@@ -56,3 +56,4 @@ ASCOOD,T2FNorm,79.22 ± 0.28,87.90 ± 0.22,76.75 ± 0.08,No,ResNet18,100 epochs
 CrossEntropy,AdaSCALE-A,81.04 ± 0.11,81.84 ± 0.36,77.25 ± 0.10,No,ResNet18,100 epochs
 CrossEntropy,AdaSCALE-L,80.54 ± 0.16,83.38 ± 0.20,77.25 ± 0.10,No,ResNet18,100 epochs
 CrossEntropy,NCI,81.03 ± 0.00,81.32 ± 0.00,77.18 ± 0.00,No,ResNet18,100 epochs
+CrossEntropy,CORE,79.11 ± 0.11,83.95 ± 0.56,77.26 ± 0.09,No,ResNet18,100 epochs

--- a/results/imagenet1k_fsood.csv
+++ b/results/imagenet1k_fsood.csv
@@ -82,3 +82,4 @@ ISH,AdaSCALE-A,69.15,89.67,54.88,No,ResNet50,official ckpt
 ISH,AdaSCALE-L,67.95,88.66,54.88,No,ResNet50,official ckpt
 CrossEntropy,AdaSCALE-A,75.04,89.77,73.28,No,RegNet_Y_16GF,torchvision ckpt
 CrossEntropy,AdaSCALE-L,73.45,91.78,73.28,No,RegNet_Y_16GF,torchvision ckpt
+CrossEntropy,CORE,62.14,77.11,60.01,No,Swin-T,torchvision ckpt

--- a/results/imagenet1k_ood.csv
+++ b/results/imagenet1k_ood.csv
@@ -96,3 +96,7 @@ CrossEntropy,MDS++,80.54,94.6,81.6,No,Swin-T,torchvision ckpt
 CrossEntropy,RMDS++,81.5,93.27,81.6,No,Swin-T,torchvision ckpt
 CrossEntropy,MDS,79.83,94.06,86.11,No,RegNet_Y_16GF,torchvision ckpt
 CrossEntropy,RMDS,84.92,94.44,86.11,No,RegNet_Y_16GF,torchvision ckpt
+CrossEntropy,CORE,77.92,95.49,76.17,No,ResNet50,torchvision ckpt
+CrossEntropy,CORE,77.75,91.34,81.14,No,ViT-B/16,torchvision ckpt
+CrossEntropy,CORE,80.83,92.23,81.60,No,Swin-T,torchvision ckpt
+CrossEntropy,CORE,90.33,98.00,86.10,No,RegNet_Y_16GF,torchvision ckpt

--- a/results/imagenet200_fsood.csv
+++ b/results/imagenet200_fsood.csv
@@ -59,3 +59,4 @@ CrossEntropy,fDBD,53.38 ± 0.16,71.26 ± 0.37,43.92 ± 0.12,No,ResNet18,90 epoch
 CrossEntropy,i-ODIN,51.37 ± 0.30,65.31 ± 0.59,43.91 ± 0.11,No,ResNet18,90 epochs
 CrossEntropy,AdaSCALE-A,57.07 ± 1.27,75.60 ± 1.60,43.92 ± 0.12,No,ResNet18,90 epochs
 CrossEntropy,AdaSCALE-L,56.65 ± 0.63,76.16 ± 0.75,43.92 ± 0.12,No,ResNet18,90 epochs
+CrossEntropy,CORE,56.26 ± 0.70,79.64 ± 0.57,43.86 ± 0.08,No,ResNet18,90 epochs

--- a/results/imagenet200_ood.csv
+++ b/results/imagenet200_ood.csv
@@ -55,3 +55,4 @@ CrossEntropy,i-ODIN,82.99 ± 0.04,91.16 ± 0.18,86.37 ± 0.08,No,ResNet18,90 epo
 CrossEntropy,AdaSCALE-A,85.52 ± 0.27,94.43 ± 0.21,86.37 ± 0.08,No,ResNet18,90 epochs
 CrossEntropy,AdaSCALE-L,85.73 ± 0.31,94.86 ± 0.12,86.37 ± 0.08,No,ResNet18,90 epochs
 CrossEntropy,NCI,83.50 ± 0.12,93.71 ± 0.12,86.37 ± 0.08,No,ResNet18,90 epochs
+CrossEntropy,CORE,83.86 ± 0.26,94.64 ± 0.09,86.37 ± 0.07,No,ResNet18,90 epochs

--- a/utils/papers.csv
+++ b/utils/papers.csv
@@ -62,3 +62,4 @@ NCI,https://arxiv.org/abs/2311.01479
 OAL,https://dl.acm.org/doi/10.1145/3731715.3733326
 MDS++,https://arxiv.org/abs/2505.18032
 RMDS++,https://arxiv.org/abs/2505.18032
+CORE,https://arxiv.org/abs/2603.18290


### PR DESCRIPTION
CORE postprocessor (8 leaderboard entries)

PR adds entries for CORE (Confidence + Orthogonal Residual Evidence), a post-hoc OOD detector that decomposes penultimate features along/orthogonal to classifier weight directions. Used with CrossEntropy-trained models, no outlier data.

**Paper:** https://arxiv.org/abs/2603.18290

### Entries
| Benchmark | Arch | Near-OOD | Far-OOD | ID Acc |
|---|---|---|---|---|
| cifar100 | ResNet18 | 79.11 ± 0.11 | 83.95 ± 0.56 | 77.26 ± 0.09 |
| imagenet200_ood | ResNet18 | 83.86 ± 0.26 | 94.64 ± 0.09 | 86.37 ± 0.07 |
| imagenet200_fsood | ResNet18 | 56.26 ± 0.70 | 79.64 ± 0.57 | 43.86 ± 0.08 |
| imagenet1k_ood | ResNet50 | 77.92 | 95.49 | 76.17 |
| imagenet1k_ood | ViT-B/16 | 77.75 | 91.34 | 81.14 |
| imagenet1k_ood | Swin-T | 80.83 | 92.23 | 81.60 |
| imagenet1k_ood | RegNet_Y_16GF | 90.33 | 98.00 | 86.10 |
| imagenet1k_fsood | Swin-T | 62.14 | 77.11 | 60.01 |

 ### Files modified
  - `results/{cifar100,imagenet200_ood,imagenet200_fsood,imagenet1k_ood,imagenet1k_fsood}.csv`
  - `utils/papers.csv` (CORE → arxiv link)

Notable: RegNet_Y_16GF imagenet1k_ood reaches 98.00 Far-OOD AUROC(#1) and 90.33 Near-OOD AUROC(#2)